### PR TITLE
Update docker-compose image name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   edgegpt-http:
-    image: edgegpt-http:latest
+    image: yoaken/edgegpt-http:latest
     container_name: edgegpt-http
     ports:
       - "8080:8080"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15166740/235033244-66af5e45-61c7-4c9d-8cab-ed06766561bc.png)

The image called edgegpt-http:latest appears to be private or missing. Instead, when I change it like below, it works fine, so can I change this?

![image](https://user-images.githubusercontent.com/15166740/235033353-0650b2aa-69df-44f3-8b24-c7d96da57118.png)

ps. This is a very good project!
